### PR TITLE
#MI-289 Started sending original error message for user creation failure scenario

### DIFF
--- a/api4/lti.go
+++ b/api4/lti.go
@@ -57,11 +57,9 @@ func signupWithLTI(c *Context, w http.ResponseWriter, r *http.Request) {
 	// create user
 	props := model.MapFromJson(r.Body)
 	user := lms.BuildUser(ltiLaunchData, props["password"])
-	user, appErr := c.App.CreateUser(user)
-
-	if appErr != nil {
+	if _, appErr := c.App.CreateUser(user); appErr != nil {
 		mlog.Error("Error occurred while creating LTI user: " + appErr.Error())
-		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.create_user.app_error", nil, appErr.Error(), appErr.StatusCode)
+		c.Err = model.NewAppError("signupWithLTI", "api.lti.signup.create_user.app_error", map[string]interface{}{"UserError": appErr.Message}, appErr.Error(), appErr.StatusCode)
 		return
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1246,7 +1246,7 @@
   },
   {
     "id": "api.lti.signup.create_user.app_error",
-    "translation": "There was an error with LTI signup attempt. Please try again or contact your system administrator. Error code LTI-11"
+    "translation": "There was an error with LTI signup attempt. {{.UserError}} Please try again or contact your system administrator. Error code LTI-11"
   },
   {
     "id": "api.oauth.allow_oauth.redirect_callback.app_error",


### PR DESCRIPTION
#### Summary
Started sending original error message for user creation failure scenario

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
